### PR TITLE
Add small logo to config file

### DIFF
--- a/site/pelicanconf.py
+++ b/site/pelicanconf.py
@@ -11,9 +11,9 @@ SITEURL = 'http://localhost:8081'
 
 # Plugins
 PLUGIN_PATHS = ['../plugins/']
-PLUGINS = [ 
-  'i18n_subsites', 
-  'pelican_youtube', 
+PLUGINS = [
+  'i18n_subsites',
+  'pelican_youtube',
   'pelican_vimeo',
   'search',
 ]
@@ -56,6 +56,7 @@ EXTRA_PATH_METADATA = {
 
 # Logo path, needs to be stored in PATH Setting
 LOGO = '/images/logo.svg'
+LOGO_SMALL = '/images/about/about.svg'
 
 # Special content
 HERO = [


### PR DESCRIPTION
This PR addresses https://github.com/space-ros/spaceros.org/issues/3 (alongside https://github.com/mjeronimo/pelican-fh5co-marble/pull/4).

We now have a `LOGO_SMALL` configuration we can use. I reused the `about.svg` image for it, but in the future the logos change, we can set them here accordingly.

Can you ptal @mjeronimo ?