### PR TITLE
Deploy to Github Pages automatically + HTTPS fixes

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -1,0 +1,40 @@
+name: Deploy Website to Github Pages
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        # Install Python and Pelican.
+        python -m pip install --upgrade pip
+        python -m pip install "pelican[markdown]"
+        # Install Stork.
+        cd /usr/bin/
+        sudo wget https://files.stork-search.net/releases/v1.5.0/stork-ubuntu-20-04
+        sudo chmod +x stork-ubuntu-20-04
+        sudo ln -s stork-ubuntu-20-04 stork
+    # Build the website for Production.
+    - name: Build
+      run: |
+        cd site
+        pelican content -s publishconf.py
+    # Deploy the site built into the gh-pages branch.
+    # You need to configure pages to be at gh-pages and serve the root folder.
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: site/output
+        branch: gh-pages

--- a/site/pelicanconf.py
+++ b/site/pelicanconf.py
@@ -6,7 +6,6 @@ import os
 AUTHOR = 'Michael Jeronimo'
 SITENAME = 'SpaceROS'
 SITEDESCRIPTION = 'The Space ROS website'
-#SITEURL = 'https://space-ros.github.io/spaceros.org'
 SITEURL = 'http://localhost:8081'
 
 # Plugins

--- a/site/publishconf.py
+++ b/site/publishconf.py
@@ -10,7 +10,10 @@ import sys
 sys.path.append(os.curdir)
 from pelicanconf import *
 
-SITEURL = 'https://space-ros.github.io/spaceros.org'
+# DEVNOTE: This is not the Github Pages URL, rather the custom domain used.
+# The redirects may cause unwanted HTTPS-related issues which are solved by
+# using the custom domain directly.
+SITEURL = 'https://space.ros.org'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'


### PR DESCRIPTION
This PR allows us to automatically build and deploy the site to `gh-pages` whenever we push changes into [master](https://github.com/space-ros/spaceros.org/tree/master).

Attempts to fix:
- https://github.com/space-ros/spaceros.org/issues/4
- https://github.com/space-ros/spaceros.org/issues/5
- https://github.com/space-ros/spaceros.org/issues/7

---

## Workflow

The included workflow is in charge of:
- Getting the code, submodules and installing dependencies.
- Build the website with the Production settings (`publishconf.py`)
- Copy the contents of `site/output` into the root of the [gh-pages](https://github.com/space-ros/spaceros.org/tree/gh-pages) branch.

**Note:** We need to set the repository's pages to serve the root folder of gh-pages this way. I believe it's more straightforward this way, and we don't depend on a `/docs` folder, for example.

---

## Regarding HTTPS

Currently, the site is served without enforcing HTTPS (http://space.ros.org/). When we visit it's HTTPS counterpart, things break (https://space.ros.org/).

To fix this, I believe we need to attack this problem on two fronts:

1) Change the SITEURL to be space.ros.org instead of the Github assigned URL. Otherwise we get mixed content and some redirects internal to the blog are not aware of the proper URL.

1) In order to enforce HTTPS, we need to have space.ros.org as a Verified Domain inside Github, and make sure the DNS records are correct.

### About the Domain Verification

The owner of @space-ros organization can do that. See [Verifying your custom domain for GitHub Pages](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/verifying-your-custom-domain-for-github-pages). To verify the domain, we need a TXT record to be set at the DNS level. Maybe @nuclearsandwich can gives us a hand on that part.

---

Can you ptal @mjeronimo ? If you can give me access to this repository's settings regarding pages, I can double check that the custom domain and pages are working as intended.