### PR TITLE
Resources

### DIFF
--- a/site/content/pages/en/resources.rst
+++ b/site/content/pages/en/resources.rst
@@ -1,0 +1,48 @@
+Resources
+#########
+
+:order: 3
+:date: 2022-12-19 00:00
+:icon: icon-folder
+:summary: Useful resources of Space ROS
+:lang: en
+:slug: resources
+:use_disqus: false
+
+Useful resources of Space ROS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Space ROS Docs
+--------------
+
+The Space ROS docs provide more in-depth guides, demos and tutorials.
+
+* Link to `Space ROS Docs <https://space-ros.github.io/docs/rolling/index.html>`_
+
+Space ROS Docker Images
+-----------------------
+
+Check out the Docker images of Space ROS.
+
+* Link to `Space ROS Docker Images <https://hub.docker.com/r/osrf/space-ros>`_
+
+Space ROS Github Organization
+-----------------------------
+
+The Space ROS Github organization has several repositories that contain various parts of the Space ROS work.
+
+* Link to `Space ROS Github Organization <https://github.com/space-ros>`_
+
+ROS Answers
+-----------
+
+Questions and answers from the ROS community.
+
+* Link to `ROS Answers <https://answers.ros.org/questions/>`_
+
+ROS Discourse
+-------------
+
+A forum for announcements, news, and discussions of ROS in general.
+
+* Link to `ROS Discourse <https://discourse.ros.org/>`_

--- a/site/content/pages/en/resources.rst
+++ b/site/content/pages/en/resources.rst
@@ -15,34 +15,24 @@ Useful resources of Space ROS
 Space ROS Docs
 --------------
 
-The Space ROS docs provide more in-depth guides, demos and tutorials.
-
-* Link to `Space ROS Docs <https://space-ros.github.io/docs/rolling/index.html>`_
+The `Space ROS Docs <https://space-ros.github.io/docs/rolling/index.html>`_ provide more in-depth guides, demos and tutorials.
 
 Space ROS Docker Images
 -----------------------
 
-Check out the Docker images of Space ROS.
-
-* Link to `Space ROS Docker Images <https://hub.docker.com/r/osrf/space-ros>`_
+Check out the `Space ROS Docker Hub <https://hub.docker.com/r/osrf/space-ros>`_ for Docker images.
 
 Space ROS Github Organization
 -----------------------------
 
-The Space ROS Github organization has several repositories that contain various parts of the Space ROS work.
-
-* Link to `Space ROS Github Organization <https://github.com/space-ros>`_
+The `Space ROS Github Organization <https://github.com/space-ros>`_ has several repositories that contain various parts of the Space ROS work.
 
 ROS Answers
 -----------
 
-Questions and answers from the ROS community.
-
-* Link to `ROS Answers <https://answers.ros.org/questions/>`_
+In `ROS Answers <https://answers.ros.org/questions/>`_ you can find questions and answers from the ROS community.
 
 ROS Discourse
 -------------
 
-A forum for announcements, news, and discussions of ROS in general.
-
-* Link to `ROS Discourse <https://discourse.ros.org/>`_
+The `ROS Discourse <https://discourse.ros.org/>`_ is a forum for announcements, news, and discussions of ROS in general.


### PR DESCRIPTION
This PR addresses #19 .

One of the issues found in the website is that links to Docs and Dockerhub were not easy to find.

This PR adds a Resources section in the sidenav, which compiles imporant links users may need.

The Getting Started page also mentions them, but users need to scan for those links if they want them. The Getting Started page should be a guide for users, and the Resource page, an easy way to navigate to important parts of the project.

Can you ptal @nuclearsandwich ?

## Screenshot

![localhost_8081_pages_resources html (1)](https://user-images.githubusercontent.com/14120807/208542164-d72455ec-4be5-44d5-8c79-b1362daec728.png)
